### PR TITLE
feat: use C as a base class for less clutter

### DIFF
--- a/examples/Alphabet.cs
+++ b/examples/Alphabet.cs
@@ -18,20 +18,20 @@ namespace examples;
 //#include <stdio.h>
 using stdc;
 
-public class Alphabet
+public class Alphabet : C
 {
 
     public static void main()
     {
-        C.FILE pFile;
+        FILE pFile;
         char c;
 
-        pFile = C.fopen("alphabet.txt", "wt");
+        pFile = fopen("alphabet.txt", "wt");
         for (c = 'A'; c <= 'Z'; c++)
         {
-            C.putc(c, pFile);
+            putc(c, pFile);
         }
-        C.fclose(pFile);
+        fclose(pFile);
     }
 
 }

--- a/examples/Assert.cs
+++ b/examples/Assert.cs
@@ -22,20 +22,20 @@ namespace examples;
 //#include <assert.h>
 using stdc;
 
-public class Assert
+public class Assert : C
 {
 
     public static void print_number(object myInt)
     {
-        C.assert(myInt != C.NULL);
-        C.printf("%d\n", myInt);
+        assert(myInt != NULL);
+        printf("%d\n", myInt);
     }
 
     public static void main()
     {
         int a = 10;
-        object b = C.NULL;
-        object c = C.NULL;
+        var b = NULL;
+        var c = NULL;
         b = a;
         print_number(b);
         print_number(c);

--- a/examples/Atexit.cs
+++ b/examples/Atexit.cs
@@ -19,24 +19,24 @@ namespace examples;
 
 using stdc;
 
-public class Atexit
+public class Atexit : C
 {
 
     public static void atexit_handler1()
     {
-        C.puts("handler 1");
+        puts("handler 1");
     }
 
     public static void atexit_handler2()
     {
-        C.puts("handler 2");
+        puts("handler 2");
     }
 
     public static void main()
     {
-        C.atexit(atexit_handler1);
-        C.atexit(atexit_handler2);
-        C.puts("atexit handlers should be called in reverse order 2 and then 1!");
+        atexit(atexit_handler1);
+        atexit(atexit_handler2);
+        puts("atexit handlers should be called in reverse order 2 and then 1!");
     }
 
 }

--- a/examples/FileCopy.cs
+++ b/examples/FileCopy.cs
@@ -33,38 +33,38 @@ namespace examples;
 //#include <stdlib.h>
 using stdc;
 
-public class FileCopy
+public class FileCopy : C
 {
 
     //int main(int argc, char * argv[])
     public static int main(int argc, string[] argv)
     {
-        C.FILE fin, fout;
+        FILE fin, fout;
         int c;  // char would need explicit conversions with the current API
-                // and the comparison with C.EOF would always fail, resulting in an
+                // and the comparison with EOF would always fail, resulting in an
                 // endless loop!
 
         if (argc != 3)
         {
-            C.printf("Usage: %s filein fileout\n", argv[0]);
-            C.exit(0);
+            printf("Usage: %s filein fileout\n", argv[0]);
+            exit(0);
         }
-        if ((fin = C.fopen(argv[1], "rb")) == C.NULL)
+        if ((fin = fopen(argv[1], "rb")) == NULL)
         {
-            C.perror("fopen filein");
-            C.exit(0);
+            perror("fopen filein");
+            exit(0);
         }
-        if ((fout = C.fopen(argv[2], "wb")) == C.NULL)
+        if ((fout = fopen(argv[2], "wb")) == NULL)
         {
-            C.perror("fopen fileout");
-            C.exit(0);
+            perror("fopen fileout");
+            exit(0);
         }
 
-        while ((c = C.getc(fin)) != C.EOF)
-            C.putc(c, fout);
+        while ((c = getc(fin)) != EOF)
+            putc(c, fout);
 
-        C.fclose(fin);
-        C.fclose(fout);
+        fclose(fin);
+        fclose(fout);
         return 0;
     }
 }

--- a/examples/HelloWorld.cs
+++ b/examples/HelloWorld.cs
@@ -10,7 +10,7 @@ namespace examples;
 //#include <stdio.h>
 using stdc;
 
-public class HelloWorld
+public class HelloWorld : C
 {
 
     //void main(void) {
@@ -19,7 +19,7 @@ public class HelloWorld
     //}
     public static void main()
     {
-        C.printf("Hello World!\n");
+        printf("Hello World!\n");
     }
 
 }

--- a/examples/Power2.cs
+++ b/examples/Power2.cs
@@ -43,7 +43,7 @@ namespace examples;
 //#include <stdio.h>
 using stdc;
 
-public class Power2
+public class Power2 : C
 {
 
     private const int N = 16;
@@ -53,11 +53,11 @@ public class Power2
         int n;          // The current exponent
         int val = 1;    // The current power of 2
 
-        C.printf("\t  n  \t    2^n\n");
-        C.printf("\t================\n");
+        printf("\t  n  \t    2^n\n");
+        printf("\t================\n");
         for (n = 0; n <= N; n++)
         {
-            C.printf("\t%3d \t %6d\n", n, val);
+            printf("\t%3d \t %6d\n", n, val);
             val = 2 * val;
         }
         return 0;

--- a/examples/Program.cs
+++ b/examples/Program.cs
@@ -1,48 +1,63 @@
 ﻿namespace examples;
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
 using stdc;
 
-public partial class Program
+public partial class Program : C
 {
     static void Main (string[] args)
     {
-        C.printf("------- Sscanf\n");
-        C.RunVMain (args, Sscanf.main);
-        C.printf("------- Qsort\n");
-        C.RunVMain (args, Qsort.main);
-        C.printf("------- Random1\n");
-        C.RunVMain (args, Random.main_srand);
-        C.printf("------- Random2\n");
-        C.RunVMain (args, Random.main_rand);
-        C.printf("------- Atexit\n");
-        C.RunVMain (args, Atexit.main);
-        //C.printf("------- Signal\n");
-        //C.RunVMain (args, Signal.main_term);
-        C.printf("------- Signal\n");
-        C.RunVMain (args, Signal.main_fpe);
-        C.printf("------- HelloWorld\n");
-        C.RunVMain (args, HelloWorld.main);
-        // C.printf("------- Assert\n");
-        // C.RunVMain (args, Assert.main);
-        C.printf("------- Strcat1\n");
-        C.RunVMain (args, Strcat.main);
-        C.printf("------- Strcat2\n");
-        C.RunVMain (args, Strcat.main2);
-        C.printf("------- Strncpy1\n");
-        C.RunVMain (args, Strncpy.main);
-        C.printf("------- Strncpy2\n");
-        C.RunVMain (args, Strncpy.main2);
-        C.printf("------- Power2\n");
-        C.RunIMain (args, Power2.main);
-        C.printf("------- Alphabet\n");
-        C.RunVMain (args, Alphabet.main);
-        C.printf("------- Filecopy\n");
-        C.RunIMain (args, FileCopy.main);
+        new Program().RunMain(args);
+    }
+
+    private void RunMain(string[] args)
+    {
+        printf("------- Sscanf\n");
+        RunVMain (args, Sscanf.main);
+
+        printf("------- Qsort\n");
+        RunVMain (args, Qsort.main);
+
+        printf("------- Random1\n");
+        RunVMain (args, Random.main_srand);
+
+        printf("------- Random2\n");
+        RunVMain (args, Random.main_rand);
+
+        printf("------- Atexit\n");
+        RunVMain (args, Atexit.main);
+
+        // printf("------- Signal\n");
+        // RunVMain (args, Signal.main_term);
+
+        printf("------- Signal\n");
+        RunVMain (args, Signal.main_fpe);
+
+        printf("------- HelloWorld\n");
+        RunVMain (args, HelloWorld.main);
+
+        // printf("------- Assert\n");
+        // RunVMain (args, Assert.main);
+
+        printf("------- Strcat1\n");
+        RunVMain (args, Strcat.main);
+
+        printf("------- Strcat2\n");
+        RunVMain (args, Strcat.main2);
+
+        printf("------- Strncpy1\n");
+        RunVMain (args, Strncpy.main);
+
+        printf("------- Strncpy2\n");
+        RunVMain (args, Strncpy.main2);
+
+        printf("------- Power2\n");
+        RunIMain (args, Power2.main);
+
+        printf("------- Alphabet\n");
+        RunVMain (args, Alphabet.main);
+
+        printf("------- Filecopy\n");
+        RunIMain (args, FileCopy.main);
     }
 
     // int main()
@@ -50,14 +65,14 @@ public partial class Program
     //     char[] str = new char[80];
     //     int i;
 
-    //     C.printf("Enter your family name: ");
-    //     C.scanf("%s", out str);
-    //     C.printf("Enter your age: ");
-    //     C.scanf("%d", out i);
-    //     C.printf("Mr. %s , %d years old.\n", str, i);
-    //     C.printf("Enter a hexadecimal number: ");
-    //     C.scanf("%x", out i);
-    //     C.printf("You have entered %#x (%d).\n", i, i);
+    //     printf("Enter your family name: ");
+    //     scanf("%s", out str);
+    //     printf("Enter your age: ");
+    //     scanf("%d", out i);
+    //     printf("Mr. %s , %d years old.\n", str, i);
+    //     printf("Enter a hexadecimal number: ");
+    //     scanf("%x", out i);
+    //     printf("You have entered %#x (%d).\n", i, i);
 
     //     return 0;
     // }
@@ -66,7 +81,7 @@ public partial class Program
     // static int Main(string[] args)
     // {
     //     var p = new Program();
-    //     return C.RunIMain(args, p.main);
+    //     return RunIMain(args, p.main);
     // }
     // #endregion
 }

--- a/examples/Qsort.cs
+++ b/examples/Qsort.cs
@@ -21,7 +21,7 @@ namespace examples;
 //#include <stdlib.h>
 using stdc;
 
-public class Qsort
+public class Qsort : C
 {
 
     public static int[] values = new int[] { 40, 10, 100, 90, 20, 25 };
@@ -34,15 +34,15 @@ public class Qsort
     public static void main_1()
     {
         int n;
-        C.qsort(values, 6, sizeof(int), compare);
+        qsort(values, 6, sizeof(int), compare);
         for (n = 0; n < 6; n++)
-            C.printf("%d ", values[n]);
+            printf("%d ", values[n]);
     }
 
     public static void main()
     {
-        C.qsort(values, compare);
+        qsort(values, compare);
         foreach (int v in values)
-            C.printf("%d ", v);
+            printf("%d ", v);
     }
 }

--- a/examples/Random.cs
+++ b/examples/Random.cs
@@ -35,17 +35,12 @@
 
 namespace examples;
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
 //#include <stdio.h>
 //#include <stdlib.h>
 //#include <time.h>
 using stdc;
 
-public class Random
+public class Random : C
 {
 
     public static void main_rand()
@@ -54,30 +49,30 @@ public class Random
         object guess;
         int iGuess;
 
-        C.srand(C.time(C.NULL));
-        iSecret = C.rand() % 10 + 1;
+        srand(time(NULL));
+        iSecret = rand() % 10 + 1;
 
         do
         {
-            C.printf("Guess the number (1 to 10): ");
-            C.scanf("%d", out guess);
+            printf("Guess the number (1 to 10): ");
+            scanf("%d", out guess);
             iGuess = (int)guess;    // can we get rid of this ugly casting here...
             if (iSecret < iGuess)
-                C.puts("The secret number is lower");
+                puts("The secret number is lower");
             else if (iSecret > iGuess)
-                C.puts("The secret number is higher");
+                puts("The secret number is higher");
         } while (iSecret != iGuess);
 
-        C.puts("Congratulations!");
+        puts("Congratulations!");
     }
 
     public static void main_srand()
     {
-        C.printf("First number: %d\n", C.rand() % 100);
-        C.srand(C.time(C.NULL));
-        C.printf("Random number: %d\n", C.rand() % 100);
-        C.srand(1);
-        C.printf("Again the first number: %d\n", C.rand() % 100);
+        printf("First number: %d\n", rand() % 100);
+        srand(time(NULL));
+        printf("Random number: %d\n", rand() % 100);
+        srand(1);
+        printf("Again the first number: %d\n", rand() % 100);
     }
 
 }

--- a/examples/Signal.cs
+++ b/examples/Signal.cs
@@ -5,23 +5,23 @@ using System.Threading;
 
 using stdc;
 
-public class Signal
+public class Signal : C
 {
 
     public static void sigterm_handler(int p)
     {
-        C.puts("Received SIGTERM");
+        puts("Received SIGTERM");
     }
 
     public static void sigfpe_handler(int p)
     {
-        C.puts("Received SIGFPE");
+        puts("Received SIGFPE");
     }
 
     public static void main_term()
     {
-        C.signal(C.SIGTERM, sigterm_handler);
-        C.puts("Push Ctrl+C to break the process");
+        signal(SIGTERM, sigterm_handler);
+        puts("Push Ctrl+C to break the process");
         while (true)
         {
             Thread.Sleep(100);
@@ -30,7 +30,7 @@ public class Signal
 
     public static void main_fpe()
     {
-        C.signal(C.SIGFPE, sigfpe_handler);
+        signal(SIGFPE, sigfpe_handler);
         int j;
         for (int i = 0; i < 10; i++)
             j = i / i;

--- a/examples/Sscanf.cs
+++ b/examples/Sscanf.cs
@@ -19,7 +19,7 @@ namespace examples;
 
 using stdc;
 
-class Sscanf
+class Sscanf : C
 {
 
     public static void main()
@@ -27,13 +27,13 @@ class Sscanf
         object str; // we loose the type here due to limitations on 'out'
         object i;   // and 'params' doesn't seem of any help either...
 
-        C.printf("Enter your family name: ");
-        C.scanf("%s", out str);
-        C.printf("Enter your age: ");
-        C.scanf("%d", out i);
-        C.printf("Mr. %s, %d years old.\n", str, i);
-        C.printf("Enter a hexadecimal number: ");
-        C.scanf("%x", out i);
-        C.printf("You have entered %#x (%d).\n", i, i);
+        printf("Enter your family name: ");
+        scanf("%s", out str);
+        printf("Enter your age: ");
+        scanf("%d", out i);
+        printf("Mr. %s, %d years old.\n", str, i);
+        printf("Enter a hexadecimal number: ");
+        scanf("%x", out i);
+        printf("You have entered %#x (%d).\n", i, i);
     }
 }

--- a/examples/Strcat.cs
+++ b/examples/Strcat.cs
@@ -18,26 +18,26 @@ namespace examples;
 using stdc;
 using System.Text;
 
-public class Strcat
+public class Strcat : C
 {
 
     public static void main()
     {
         char[] str = new char[80];
-        C.strcpy(str, "these ");
-        C.strcat(str, "strings ");
-        C.strcat(str, "are ");
-        C.strcat(str, "concatenated.");
-        C.puts(str);
+        strcpy(str, "these ");
+        strcat(str, "strings ");
+        strcat(str, "are ");
+        strcat(str, "concatenated.");
+        puts(str);
     }
 
     public static void main2()
     {
         StringBuilder str = new StringBuilder(80);
-        C.strcpy(str, "these ");
-        C.strcat(str, "strings ");
-        C.strcat(str, "are ");
-        C.strcat(str, "concatenated.");
-        C.puts(str);
+        strcpy(str, "these ");
+        strcat(str, "strings ");
+        strcat(str, "are ");
+        strcat(str, "concatenated.");
+        puts(str);
     }
 }

--- a/examples/Strncpy.cs
+++ b/examples/Strncpy.cs
@@ -17,22 +17,22 @@ namespace examples;
 using stdc;
 using System.Text;
 
-public class Strncpy
+public class Strncpy : C
 {
     public static void main()
     {
         string str1 = "To be or not to be";
         char[] str2 = new char[6];
-        C.strncpy(str2, str1, 5);
+        strncpy(str2, str1, 5);
         str2[5] = '\0';
-        C.puts(str2);
+        puts(str2);
     }
 
     public static void main2()
     {
         string str1 = "To be or not to be";
         StringBuilder str2 = new StringBuilder(6);
-        C.strncpy(str2, str1, 5);
-        C.puts(str2);
+        strncpy(str2, str1, 5);
+        puts(str2);
     }
 }

--- a/stdc/args.cs
+++ b/stdc/args.cs
@@ -2,7 +2,7 @@
 
 using System;
 
-public static partial class C
+public partial class C
 {
 
     public delegate int imain1(int argc, string[] argv);
@@ -12,8 +12,8 @@ public static partial class C
 
     public static int RunIMain(string[] args, imain1 main)
     {
-        int argc = C.ToArgc(args);
-        string[] argv = C.ToArgv(args);
+        int argc = ToArgc(args);
+        string[] argv = ToArgv(args);
         int ret = 0;
         try
         {
@@ -49,8 +49,8 @@ public static partial class C
         int ret = 0;
         try
         {
-            int argc = C.ToArgc(args);
-            string[] argv = C.ToArgv(args);
+            int argc = ToArgc(args);
+            string[] argv = ToArgv(args);
             main(argc, argv);
             return ret;
         }

--- a/stdc/assert.cs
+++ b/stdc/assert.cs
@@ -7,7 +7,7 @@ namespace stdc;
 using System;
 using System.Diagnostics;
 
-public static partial class C
+public partial class C
 {
     /// <summary>
     ///		void assert (int expression);

--- a/stdc/conio.cs
+++ b/stdc/conio.cs
@@ -2,7 +2,7 @@
 
 using System;
 
-public static partial class C
+public partial class C
 {
     [Obsolete("non standard conio.h support")]
     public static void clrscr()

--- a/stdc/errno.cs
+++ b/stdc/errno.cs
@@ -1,6 +1,6 @@
 ﻿namespace stdc;
 
-public static partial class C
+public partial class C
 {
 
     /// <summary>

--- a/stdc/helpers/PrintfHelper.cs
+++ b/stdc/helpers/PrintfHelper.cs
@@ -74,7 +74,7 @@ namespace stdc
                 #endregion
 
                 #region field length
-                // extract field length and 
+                // extract field length and
                 // pading character
                 paddingCharacter = ' ';
                 fieldLength = int.MinValue;

--- a/stdc/locale.cs
+++ b/stdc/locale.cs
@@ -1,6 +1,6 @@
 ﻿namespace stdc;
 
-public static partial class C
+public partial class C
 {
 
     public static readonly int LC_ALL = 0;

--- a/stdc/math.cs
+++ b/stdc/math.cs
@@ -2,7 +2,7 @@
 
 using System;
 
-public static partial class C
+public partial class C
 {
 
     #region Trigonometric functions

--- a/stdc/signal.cs
+++ b/stdc/signal.cs
@@ -2,7 +2,7 @@
 
 using System;
 
-public static partial class C
+public partial class C
 {
     /* signals */
 

--- a/stdc/stdio.cs
+++ b/stdc/stdio.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Collections.Generic;
 using System.Text;
 
-public static partial class C
+public partial class C
 {
 
     #region FILE

--- a/stdc/stdlib.cs
+++ b/stdc/stdlib.cs
@@ -13,7 +13,7 @@ public enum EXIT_STATUS
 }
 
 
-public static partial class C
+public partial class C
 {
 
     //#define NULL ((void *) 0)

--- a/stdc/string.cs
+++ b/stdc/string.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Text;
 
-public static partial class C
+public partial class C
 {
 
     //void * memchr(const void *, int, size_t);

--- a/stdc/time.cs
+++ b/stdc/time.cs
@@ -26,7 +26,7 @@ public struct clock_t
     public long _clock_t;
 }
 
-public static partial class C
+public partial class C
 {
 
 


### PR DESCRIPTION
C used as a base class is a preferred method for porting, even if that pulls in loads of names in the scope of the implementing class. Anyways that would be the case in C. In case of conflicts there is still the possibility for a project to delete some unused portions of the C class.